### PR TITLE
set all containers that affect tree-surface to 50vw

### DIFF
--- a/empress/support_files/css/empress.css
+++ b/empress/support_files/css/empress.css
@@ -365,8 +365,8 @@ canvas {
     position: fixed;
     top: 0vh;
     left: 0vw;
-    width: inherit;
-    height: 100vw;
+    width: 50vw;
+    height: 50vw;
 }
 
 /* referenced from  https://webglfundamentals.org/webgl/lessons/webgl-text-html.html*/
@@ -375,14 +375,14 @@ canvas {
     top: 0vh;
     left: 0vw;
     overflow: hidden;
-    width: inherit;
-    height: 100vh;
+    width: 50vw;
+    height: 50vw;
 }
 
 #tree-container {
     overflow: hidden;
-    width: 50%;
-    height: 100vh;
+    width: 50vw;
+    height: 50vw;
 }
 
 #dvicontainer {


### PR DESCRIPTION
I set all containers associated with tree-surface (which holds/becomes the webgl canvas) to 50vw. You will need to play around with different sizes. I'm pretty sure the issue was the width was set to 50% while the height remained the same.